### PR TITLE
Rework config::section to use resource name as table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Different sections of Traefik's TOML configuration file can be defined with the 
 traefik::config::section { 'web':
   description => 'API backend',
   order       => '10',
-  hash        => {
-    'web' => {'address' => ':9090'}
-  }
+  hash        => {'address' => ':9090'}
 }
 ```
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,7 @@ class traefik::config (
   traefik::config::section { 'main':
     order       => '01',
     hash        => $config_hash,
+    table       => false,
     description => 'Main section'
   }
 }

--- a/manifests/config/section.pp
+++ b/manifests/config/section.pp
@@ -32,9 +32,8 @@ define traefik::config::section (
   }
 
   if $table {
-    $real_hash = {
-      $table => $hash
-    }
+    # Have to put $table in string literal for Puppet 3 parser to be happy
+    $real_hash = {"${table}" => $hash}
   } else {
     $real_hash = $hash
   }

--- a/manifests/config/section.pp
+++ b/manifests/config/section.pp
@@ -5,6 +5,10 @@
 # [*hash*]
 #   The hash of config options to put in this section of the config file.
 #
+# [*table*]
+#   The TOML table for this section of config. This defaults to the resource's
+#   name.
+#
 # [*order*]
 #   The order of this section (concat fragment) within the config file.
 #
@@ -12,7 +16,8 @@
 #   A short description of this section. If provided, a header will be created
 #   for this section in the config file.
 define traefik::config::section (
-  $hash,
+  $hash        = {},
+  $table       = $name,
   $order       = '20',
   $description = undef
 ) {
@@ -26,9 +31,17 @@ define traefik::config::section (
     }
   }
 
+  if $table {
+    $real_hash = {
+      $table => $hash
+    }
+  } else {
+    $real_hash = $hash
+  }
+
   concat::fragment { "traefik_${name}":
     target  => $traefik::config::config_path,
     order   => "${order}-1",
-    content => traefik_toml($hash)
+    content => traefik_toml($real_hash)
   }
 }

--- a/spec/defines/config_section_spec.rb
+++ b/spec/defines/config_section_spec.rb
@@ -7,9 +7,7 @@ describe 'traefik::config::section' do
 
       let(:title) { 'test' }
 
-      describe 'when hash is passed' do
-        let(:params) { {:hash => {'test' => 'abc'}} }
-
+      describe 'with default parameters' do
         it { is_expected.to compile }
         it { is_expected.to contain_class('traefik::config') }
 
@@ -21,23 +19,24 @@ describe 'traefik::config::section' do
           is_expected.to contain_concat__fragment('traefik_test')
             .with_target('/etc/traefik/traefik.toml')
             .with_order('20-1')
-            .with_content(/^test = "abc"$/)
+            .with_content("[test]\n")
         end
       end
 
-      describe 'when hash is not passed' do
+      describe 'when hash is passed' do
+        let(:params) { {:hash => {'key' => 'value'}} }
+
         it do
-          is_expected.to compile.and_raise_error(mustpass('hash'))
+          is_expected.to contain_concat__fragment('traefik_test')
+            .with_target('/etc/traefik/traefik.toml')
+            .with_order('20-1')
+            .with_content(/^\[test\]$/)
+            .with_content(/^key = "value"$/)
         end
       end
 
       describe 'when description is passed' do
-        let(:params) do
-          {
-            :hash => {'test' => 'abc'},
-            :description => 'Test section'
-          }
-        end
+        let(:params) { {:description => 'Test section'} }
 
         it do
           is_expected.to contain_concat__fragment('traefik_test_header')
@@ -45,19 +44,11 @@ describe 'traefik::config::section' do
             .with_order('20-0')
             .with_content(/Test section/)
         end
-
-        it do
-          is_expected.to contain_concat__fragment('traefik_test')
-            .with_target('/etc/traefik/traefik.toml')
-            .with_order('20-1')
-            .with_content(/^test = "abc"$/)
-        end
       end
 
       describe 'when a custom order is set' do
         let(:params) do
           {
-            :hash => {'test' => 'abc'},
             :description => 'Test section',
             :order => '33'
           }
@@ -71,6 +62,27 @@ describe 'traefik::config::section' do
         it do
           is_expected.to contain_concat__fragment('traefik_test')
             .with_order('33-1')
+        end
+      end
+
+      describe 'when table is passed' do
+        let(:params) { {:table => 'tabular'} }
+        it do
+          is_expected.to contain_concat__fragment('traefik_test')
+            .with_content("[tabular]\n")
+        end
+      end
+
+      describe 'when table is false' do
+        let(:params) do
+          {
+            :table => false,
+            :hash => {'key' => 'value'}
+          }
+        end
+        it do
+          is_expected.to contain_concat__fragment('traefik_test')
+            .with_content("key = \"value\"\n")
         end
       end
     end


### PR DESCRIPTION
* Fewer redundant keys in the config hash
* Allow no hash to be passed, makes it easy to enable features with
  default config