### PR TITLE
Relax version requirement for puppetlabs/concat dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs-concat",
-      "version_requirement": ">= 2.1.0"
+      "version_requirement": ">= 1.1.0"
     }
   ],
   "requirements": [

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'traefik::config' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { facts.merge(:concat_basedir => '/tmp/concat') }
 
       describe 'with default parameters' do
         it { should compile }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'traefik' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { facts.merge(:concat_basedir => '/tmp/concat') }
 
       describe 'with default parameters' do
         it { is_expected.to compile }

--- a/spec/defines/config_section_spec.rb
+++ b/spec/defines/config_section_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'traefik::config::section' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { facts.merge(:concat_basedir => '/tmp/concat') }
 
       let(:title) { 'test' }
 


### PR DESCRIPTION
Some other modules we use still require an older version of the module which causes a dependency conflict. See luxflux/puppet-openvpn#202.