### PR TITLE
Provide an easier way to add file rules

### DIFF
--- a/manifests/config/file.pp
+++ b/manifests/config/file.pp
@@ -45,9 +45,10 @@ class traefik::config::file (
   }
 
   traefik::config::section { 'file':
-    order => '10',
-    hash  => merge($base_hash, {
+    order       => '10',
+    hash        => merge($base_hash, {
       'watch' => $watch
-    })
+    }),
+    description => 'File configuration backend'
   }
 }

--- a/manifests/config/file.pp
+++ b/manifests/config/file.pp
@@ -1,0 +1,53 @@
+# == Class: traefik::config::file
+#
+# === Parameters
+#
+# [*filename*]
+#   The filename of the file in which to put rules for the file provider. If
+#   set, a new config file will be created and all traefik::config::file_rule
+#   resources will be added to the file. If unset, rules will be added to the
+#   main Traefik config file.
+#
+# [*watch*]
+#   Whether or not to watch the config for changes to the file rules. This
+#   should be used together with *filename* as changes to the main Traefik
+#   config file will trigger a restart or Traefik.
+class traefik::config::file (
+  $filename = undef,
+  $watch    = false,
+) {
+  include traefik::config
+
+  if $filename != undef {
+    $rules_path = "${traefik::config::config_dir}/${filename}"
+
+    concat { $rules_path:
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      require => File[$traefik::config::config_dir],
+      before  => Traefik::Config::Section['file']
+    }
+
+    # Set these variables for the template
+    $config_file = $filename
+    $config_file_description = 'File configuration'
+    concat::fragment { 'traefik_rules_header':
+      target  => $rules_path,
+      order   => '00',
+      content => template('traefik/config_file_header.toml.erb')
+    }
+
+    $base_hash = {'filename' => $rules_path}
+  } else {
+    $rules_path = $traefik::config::config_path
+    $base_hash = {}
+  }
+
+  traefik::config::section { 'file':
+    order => '10',
+    hash  => merge($base_hash, {
+      'watch' => $watch
+    })
+  }
+}

--- a/manifests/config/file_rule.pp
+++ b/manifests/config/file_rule.pp
@@ -1,0 +1,47 @@
+# == Define: traefik::config::file_rule
+#
+# === Parameters
+#
+# [*frontend*]
+#   The hash for the frontend rule for this service. The backend for this
+#   frontend will be set to the backend created in this resource.
+#
+# [*backend*]
+#   The hash for the backend rule for this service.
+#
+# [*order*]
+#   The concat fragment order for the sections in this rule.
+#
+# [*description*]
+#   A short description of this section. If provided, a header will be created
+#   for this section in the config file.
+define traefik::config::file_rule (
+  $frontend    = {},
+  $backend     = {},
+  $order       = '30',
+  $description = undef
+) {
+  include traefik::config::file
+
+  $real_frontend = merge($frontend, {
+    'backend' => "${name}-backend"
+  })
+  traefik::config::section { "${name}-frontend":
+    table       => 'frontends',
+    order       => "${order}-0",
+    hash        => {
+      "${name}-frontend" => $real_frontend, # lint:ignore:arrow_alignment
+    },
+    description => $description,
+    target      => $traefik::config::file::rules_path
+  }
+
+  traefik::config::section { "${name}-backend":
+    table  => 'backends',
+    order  => "${order}-1",
+    hash   => {
+      "${name}-backend" => $backend, # lint:ignore:arrow_alignment
+    },
+    target => $traefik::config::file::rules_path
+  }
+}

--- a/manifests/config/section.pp
+++ b/manifests/config/section.pp
@@ -15,17 +15,28 @@
 # [*description*]
 #   A short description of this section. If provided, a header will be created
 #   for this section in the config file.
+#
+# [*target*]
+#   The target concat resource for the fragments in this section. Generally,
+#   this is for internal use only.
 define traefik::config::section (
   $hash        = {},
   $table       = $name,
   $order       = '20',
-  $description = undef
+  $description = undef,
+  $target      = undef,
 ) {
   include traefik::config
 
+  if $target == undef {
+    $real_target = $traefik::config::config_path
+  } else {
+    $real_target = $target
+  }
+
   if $description != undef {
     concat::fragment { "traefik_${name}_header":
-      target  => $traefik::config::config_path,
+      target  => $real_target,
       order   => "${order}-0",
       content => template('traefik/config_section_header.toml.erb')
     }
@@ -39,7 +50,7 @@ define traefik::config::section (
   }
 
   concat::fragment { "traefik_${name}":
-    target  => $traefik::config::config_path,
+    target  => $real_target,
     order   => "${order}-1",
     content => traefik_toml($real_hash)
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "praekeltfoundation-traefik",
-  "version": "0.1.2-dev",
+  "version": "0.2.0-dev",
   "author": "Jamie Hewland",
   "summary": "Module to manage the Traefik reverse proxy",
   "license": "MIT",

--- a/spec/classes/config_file_spec.rb
+++ b/spec/classes/config_file_spec.rb
@@ -13,6 +13,14 @@ describe 'traefik::config::file' do
           is_expected.to contain_traefik__config__section('file')
             .with_order('10')
             .with_hash('watch' => false)
+            .with_description('File configuration backend')
+        end
+
+        it do
+          is_expected.to contain_concat__fragment('traefik_file_header')
+            .with_target('/etc/traefik/traefik.toml')
+            .with_order('10-0')
+            .with_content(/File configuration backend/)
         end
 
         it do

--- a/spec/classes/config_file_spec.rb
+++ b/spec/classes/config_file_spec.rb
@@ -14,6 +14,14 @@ describe 'traefik::config::file' do
             .with_order('10')
             .with_hash('watch' => false)
         end
+
+        it do
+          is_expected.to contain_concat__fragment('traefik_file')
+            .with_target('/etc/traefik/traefik.toml')
+            .with_order('10-1')
+            .with_content(/^\[file\]$/)
+            .with_content(/^watch = false$/)
+        end
       end
 
       describe 'when filename is passed' do

--- a/spec/classes/config_file_spec.rb
+++ b/spec/classes/config_file_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'traefik::config::file' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts.merge(:concat_basedir => '/tmp/concat') }
+
+      describe 'with default parameters' do
+        it { is_expected.to compile }
+
+        it { is_expected.to contain_class('traefik::config') }
+        it do
+          is_expected.to contain_traefik__config__section('file')
+            .with_order('10')
+            .with_hash('watch' => false)
+        end
+      end
+
+      describe 'when filename is passed' do
+        let(:params) { {:filename => 'rules.toml'} }
+
+        it do
+          is_expected.to contain_concat('/etc/traefik/rules.toml')
+            .with_ensure('present')
+            .with_owner('root')
+            .with_group('root')
+            .that_requires('File[/etc/traefik]')
+            .that_comes_before('Traefik::Config::Section[file]')
+        end
+
+        it do
+          is_expected.to contain_concat__fragment('traefik_rules_header')
+            .with_target('/etc/traefik/rules.toml')
+            .with_order('00')
+            .with_content(/WARNING: This file is managed by Puppet/)
+            .with_content(/rules\.toml/)
+            .with_content(/File configuration/)
+        end
+
+        it do
+          is_expected.to contain_traefik__config__section('file')
+            .with_hash(
+              'filename' => '/etc/traefik/rules.toml',
+              'watch' => false
+            )
+        end
+      end
+
+      describe 'when watch is true' do
+        let(:params) { {:watch => true} }
+        it do
+          is_expected.to contain_traefik__config__section('file')
+            .with_hash('watch' => true)
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/config_file_rule_spec.rb
+++ b/spec/defines/config_file_rule_spec.rb
@@ -20,11 +20,26 @@ describe 'traefik::config::file_rule' do
         end
 
         it do
+          is_expected.to contain_concat__fragment('traefik_test-frontend')
+            .with_target('/etc/traefik/traefik.toml')
+            .with_order('30-0-1')
+            .with_content(/^\[frontends.test-frontend\]$/)
+            .with_content(/^backend = "test-backend"$/)
+        end
+
+        it do
           is_expected.to contain_traefik__config__section('test-backend')
             .with_table('backends')
             .with_order('30-1')
             .with_hash('test-backend' => {})
             .with_target('/etc/traefik/traefik.toml')
+        end
+
+        it do
+          is_expected.to contain_concat__fragment('traefik_test-backend')
+            .with_target('/etc/traefik/traefik.toml')
+            .with_order('30-1-1')
+            .with_content("[backends.test-backend]\n")
         end
       end
 
@@ -88,6 +103,15 @@ describe 'traefik::config::file_rule' do
         it do
           is_expected.to contain_traefik__config__section('test-frontend')
             .with_description('Test setup')
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(
+            'traefik_test-frontend_header'
+          )
+            .with_target('/etc/traefik/traefik.toml')
+            .with_order('30-0-0')
+            .with_content(/Test setup/)
         end
       end
     end

--- a/spec/defines/config_file_rule_spec.rb
+++ b/spec/defines/config_file_rule_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe 'traefik::config::file_rule' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts.merge(:concat_basedir => '/tmp/concat') }
+
+      let(:title) { 'test' }
+
+      describe 'with default parameters' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_class('traefik::config::file') }
+
+        it do
+          is_expected.to contain_traefik__config__section('test-frontend')
+            .with_table('frontends')
+            .with_order('30-0')
+            .with_hash('test-frontend' => {'backend' => 'test-backend'})
+            .with_target('/etc/traefik/traefik.toml')
+        end
+
+        it do
+          is_expected.to contain_traefik__config__section('test-backend')
+            .with_table('backends')
+            .with_order('30-1')
+            .with_hash('test-backend' => {})
+            .with_target('/etc/traefik/traefik.toml')
+        end
+      end
+
+      describe 'when frontend is passed' do
+        let(:frontend) do
+          {
+            'servers' => {
+              'server1' => {
+                'url' => 'http://127.0.0.1:5000',
+                'weight' => 1
+              }
+            }
+          }
+        end
+        let(:params) { {:frontend => frontend} }
+
+        it do
+          is_expected.to contain_traefik__config__section('test-frontend')
+            .with_hash(
+              'test-frontend' => frontend.merge('backend' => 'test-backend')
+            )
+        end
+      end
+
+      describe 'when backend is passed' do
+        let(:backend) do
+          {
+            'servers' => {
+              'server1' => {
+                'url' => 'http://127.0.0.1:5000',
+                'weight' => 1
+              }
+            }
+          }
+        end
+        let(:params) { {:backend => backend} }
+
+        it do
+          is_expected.to contain_traefik__config__section('test-backend')
+            .with_hash('test-backend' => backend)
+        end
+      end
+
+      describe 'when a custom order is set' do
+        let(:params) { {:order => '42'} }
+
+        it do
+          is_expected.to contain_traefik__config__section('test-frontend')
+            .with_order('42-0')
+        end
+
+        it do
+          is_expected.to contain_traefik__config__section('test-backend')
+            .with_order('42-1')
+        end
+      end
+
+      describe 'when description is passed' do
+        let(:params) { {:description => 'Test setup'} }
+
+        it do
+          is_expected.to contain_traefik__config__section('test-frontend')
+            .with_description('Test setup')
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/config_section_spec.rb
+++ b/spec/defines/config_section_spec.rb
@@ -85,6 +85,24 @@ describe 'traefik::config::section' do
             .with_content("key = \"value\"\n")
         end
       end
+
+      describe 'when a custom target is set' do
+        let(:params) do
+          {
+            :target => '/etc/traefik/rules.toml',
+            :description => 'Test section'
+          }
+        end
+        it do
+          is_expected.to contain_concat__fragment('traefik_test_header')
+            .with_target('/etc/traefik/rules.toml')
+            .with_content(/Test section/)
+        end
+        it do
+          is_expected.to contain_concat__fragment('traefik_test')
+            .with_target('/etc/traefik/rules.toml')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
It's currently quite complicated to set up `frontends` and `backends` in the main TOML config file. There's also an option to split these rules into a separate file which would probably help keep the main config file from becoming very complicated. Also, Traefik can be set to watch the extra file for changes.