### PR TITLE
Increases 'nofile' ulimit value in init scripts.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,7 @@ Style/SpaceInsideHashLiteralBraces:
 # This check errors out on Ruby 1.9.3 on Travis for some reason :-/
 Style/WordArray:
   Enabled: false
+
+# Increase linelength to match Puppet style guide
+Metrics/LineLength:
+  Max: 140

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,10 @@
 #   The directory that the Traefik binary will be symlinked into (from where it
 #   was downloaded to).
 #
+# [*max_open_files*]
+#   Integer which controls 'nofile' ulimit value in init scripts, which sets
+#   the maximum number of open files for the Traefik process.
+#
 # [*init_style*]
 #   The style of the init system on the system. If false-y then no init script
 #   will be installed. Possible values: upstart, false
@@ -58,6 +62,7 @@ class traefik (
   $download_url      = undef,
   $archive_dir       = $traefik::params::archive_dir,
   $bin_dir           = $traefik::params::bin_dir,
+  $max_open_files    = $traefik::params::max_open_files,
   $init_style        = $traefik::params::init_style,
 
   $config_dir        = $traefik::params::config_dir,
@@ -80,6 +85,7 @@ class traefik (
     download_url      => $download_url,
     archive_dir       => $archive_dir,
     bin_dir           => $bin_dir,
+    max_open_files    => $max_open_files,
     init_style        => $init_style,
     config_path       => "${config_dir}/${config_file}",
     notify            => Class['traefik::service'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,6 +44,7 @@ class traefik::install (
   $version           = $traefik::params::version,
   $os                = $traefik::params::os,
   $arch              = $traefik::params::arch,
+  $max_open_files    = $traefik::params::max_open_files,
 
   $download_url      = undef,
 
@@ -53,6 +54,9 @@ class traefik::install (
   $init_style        = $traefik::params::init_style,
   $config_path       = undef,
 ) inherits traefik::params {
+
+  validate_integer($max_open_files)
+
   case $install_method {
     'url': {
       $real_download_url = pick($download_url,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class traefik::params {
   $version           = '1.0.0'
   $archive_dir       = '/opt/puppet-archive'
   $bin_dir           = '/usr/local/bin'
+  $max_open_files    = '16384'
 
   $config_dir        = '/etc/traefik'
   $config_file       = 'traefik.toml'

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.2.0"
+      "version_requirement": ">= 4.6.0"
     },
     {
       "name": "puppet-archive",

--- a/templates/traefik.systemd.erb
+++ b/templates/traefik.systemd.erb
@@ -6,6 +6,7 @@ After=basic.target network.target
 [Service]
 ExecStart=<%= @bin_dir %>/traefik<% if @config_path %> --configFile=<%= @config_path %><% end %>
 Restart=on-failure
+LimitNOFILE=<%= @max_open_files %>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/traefik.upstart.erb
+++ b/templates/traefik.upstart.erb
@@ -8,3 +8,4 @@ exec <%= @bin_dir %>/traefik<% if @config_path %> --configFile=<%= @config_path 
 respawn
 respawn limit 10 10
 kill timeout 10
+limit nofile <%= @max_open_files %> <%= @max_open_files %>


### PR DESCRIPTION
The default maximum number of open files on many systems (1024) is not sufficient for Traefik which maintains many open sockets. Increasing this to 16384 should be a more reasonable default and should cause no trouble (AFAIK).