### PR TITLE
Clarify nested hashes in doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,27 @@ class { 'traefik':
 }
 ```
 
-Different sections of Traefik's TOML configuration file can be defined with the `traefik::config::section` type:
+Different sections of Traefik's TOML configuration file can be defined with the `traefik::config::section` type. The name of the Puppet resource, in this case 'web' is used for the top-level of the resulting hash and will result in a table [web] in the TOML file:
 ```puppet
 traefik::config::section { 'web':
   description => 'API backend',
   order       => '10',
   hash        => {'address' => ':9090'}
+}
+```
+
+Hashes can be nested to produce nested TOML tables. The following resource will output the common http and https EntryPoints.
+```puppet
+traefik::config::section { 'entryPoints':
+  hash => {
+    'http'  => {
+      'address' => ':80'
+    },
+    'https' => {
+      'address' => ':443',
+      'tls'     => {}
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
It wasn't clear how to create nested TOML tables via the traefik::config::section type.

Thanks to your explanation in https://github.com/praekeltfoundation/puppet-traefik/issues/12 I managed to get my config working. I've added an example to the README to help people get started with this module.