### PR TITLE
Adding support for Ubuntu 16.04 (Xenial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ weight = 1
 ```
 
 ## Limitations
-* Currently **only works on Ubuntu 14.04 and Debian 8** (pull requests welcome).
+* Currently **only works on Ubuntu 14.04, 16.04 and Debian 8** (pull requests welcome).
 * Uses the [`toml-rb`](https://rubygems.org/gems/toml-rb) gem to generate config with a parser function. This means that your Puppet server must have the gem correctly installed. See [this page](https://docs.puppet.com/puppetserver/latest/gems.html) for Puppet 4 instructions.
 * There is no validation on config parameters. Everything (and anything) can be specified via hashes.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 class traefik::params {
   $install_method    = 'url'
   $download_url_base = 'https://github.com/containous/traefik/releases/download'
-  $version           = '1.0.3'
+  $version           = '1.1.1'
   $archive_dir       = '/opt/puppet-archive'
   $bin_dir           = '/usr/local/bin'
   $max_open_files    = 16384

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,8 @@ class traefik::params {
   } elsif $::operatingsystem == 'Ubuntu' {
     if versioncmp($::operatingsystemrelease, '14.04') == 0 {
       $init_style = 'upstart'
+    } elsif versioncmp($::operatingsystemrelease, '16.04') == 0 {
+      $init_style = 'systemd'
     }
   }
   if $init_style == undef {

--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     }
   ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,7 +13,11 @@ describe 'traefik' do
 
         # FIXME: Find a better way to do this
         if facts[:operatingsystem] == 'Ubuntu'
-          init_style = 'upstart'
+          if facts[:operatingsystemrelease] == '14.04'
+            init_style = 'upstart'
+          elsif facts[:operatingsystemrelease] == '16.04'
+            init_style = 'systemd'
+          end
         elsif facts[:operatingsystem] == 'Debian'
           init_style = 'systemd'
         end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -75,24 +75,46 @@ describe 'traefik::install' do
           end
 
         elsif facts[:operatingsystem] == 'Ubuntu'
-          it do
-            is_expected.to contain_file('/etc/init/traefik.conf')
-              .with_content(%r{^exec /usr/local/bin/traefik$})
-              .with_content(
-                /^limit nofile #{max_open_files} #{max_open_files}$/
-              )
-              .with_owner('root')
-              .with_group('root')
-              .with_mode('0444')
+
+          if facts[:operatingsystemrelease] == '14.04'
+            it do
+              is_expected.to contain_file('/etc/init/traefik.conf')
+                .with_content(%r{^exec /usr/local/bin/traefik$})
+                .with_content(
+                  /^limit nofile #{max_open_files} #{max_open_files}$/
+                )
+                .with_owner('root')
+                .with_group('root')
+                .with_mode('0444')
+            end
+
+            it do
+              is_expected.to contain_file('/etc/init.d/traefik')
+                .with_ensure('link')
+                .with_target('/lib/init/upstart-job')
+                .with_owner('root')
+                .with_group('root')
+            end
+
+          elsif facts[:operatingsystemrelease] == '16.04'
+            it do
+              is_expected.to contain_file('/lib/systemd/system/traefik.service')
+                .with_content(%r{^ExecStart=/usr/local/bin/traefik$})
+                .with_content(/^LimitNOFILE=#{max_open_files}$/)
+                .with_owner('root')
+                .with_group('root')
+                .with_mode('0644')
+            end
+
+            it do
+              is_expected.to contain_exec('traefik-systemd-reload')
+                .with_command('systemctl daemon-reload')
+                .with_path(['/usr/bin', '/bin', '/usr/sbin'])
+                .with_refreshonly(true)
+            end
+
           end
 
-          it do
-            is_expected.to contain_file('/etc/init.d/traefik')
-              .with_ensure('link')
-              .with_target('/lib/init/upstart-job')
-              .with_owner('root')
-              .with_group('root')
-          end
         end
       end
 
@@ -238,9 +260,16 @@ describe 'traefik::install' do
               .with_content(%r{^ExecStart=/usr/bin/traefik$})
           end
         elsif facts[:operatingsystem] == 'Ubuntu'
-          it do
-            is_expected.to contain_file('/etc/init/traefik.conf')
-              .with_content(%r{^exec /usr/bin/traefik$})
+          if facts[:operatingsystemrelease] == '14.04'
+            it do
+              is_expected.to contain_file('/etc/init/traefik.conf')
+                .with_content(%r{^exec /usr/bin/traefik$})
+            end
+          elsif facts[:operatingsystemrelease] == '16.04'
+            it do
+              is_expected.to contain_file('/lib/systemd/system/traefik.service')
+                .with_content(%r{^ExecStart=/usr/bin/traefik$})
+            end
           end
         end
       end
@@ -270,9 +299,18 @@ describe 'traefik::install' do
               .with_content(/^ExecStart=#{binary} --configFile=#{config_path}$/)
           end
         elsif facts[:operatingsystem] == 'Ubuntu'
-          it do
-            is_expected.to contain_file('/etc/init/traefik.conf')
-              .with_content(/^exec #{binary} --configFile=#{config_path}$/)
+          if facts[:operatingsystemrelease] == '14.04'
+            it do
+              is_expected.to contain_file('/etc/init/traefik.conf')
+                .with_content(/^exec #{binary} --configFile=#{config_path}$/)
+            end
+          elsif facts[:operatingsystemrelease] == '16.04'
+            it do
+              is_expected.to contain_file('/lib/systemd/system/traefik.service')
+                .with_content(
+                  /^ExecStart=#{binary} --configFile=#{config_path}$/
+                )
+            end
           end
         end
       end
@@ -287,11 +325,18 @@ describe 'traefik::install' do
               .with_content(/^LimitNOFILE=#{max_open_files}$/)
           end
         elsif facts[:operatingsystem] == 'Ubuntu'
-          it do
-            is_expected.to contain_file('/etc/init/traefik.conf')
-              .with_content(
-                /^limit nofile #{max_open_files} #{max_open_files}$/
-              )
+          if facts[:operatingsystemrelease] == '14.04'
+            it do
+              is_expected.to contain_file('/etc/init/traefik.conf')
+                .with_content(
+                  /^limit nofile #{max_open_files} #{max_open_files}$/
+                )
+            end
+          elsif facts[:operatingsystemrelease] == '16.04'
+            it do
+              is_expected.to contain_file('/lib/systemd/system/traefik.service')
+                .with_content(/^LimitNOFILE=#{max_open_files}$/)
+            end
           end
         end
       end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -4,7 +4,7 @@ describe 'traefik::install' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
-      let(:version) { '1.0.3' }
+      let(:version) { '1.1.1' }
       let(:max_open_files) { 16384 }
 
       describe 'with default parameters' do


### PR DESCRIPTION
I've added support for Ubuntu 16.04.

I decided to skip the non-LTS versions of Ubuntu, to keep things simple. I'm guessing that Traefik users will likely use some Ubuntu LTS version anyway.

Since Ubuntu switched to systemd in 16.04 I've expanded the tests to check for that. The nested conditionals in the rspec tests could be prettier but I'm not sure how to clean it up. Rspec is still magic to me.

I also bumped the default Traefik version to 1.1.1.

Let me know what you think please.